### PR TITLE
Ensure default admin user exists

### DIFF
--- a/app/management/commands/create_superuser.py
+++ b/app/management/commands/create_superuser.py
@@ -7,9 +7,9 @@ class Command(BaseCommand):
 
     def handle(self, *args, **kwargs):
         User = get_user_model()
-        username = os.getenv("DJANGO_SUPERUSER_USERNAME", "revisaosegura")
+        username = os.getenv("DJANGO_SUPERUSER_USERNAME", "Revisao2025")
         email = os.getenv("DJANGO_SUPERUSER_EMAIL", "segurarevisao@gmail.com")
-        password = os.getenv("DJANGO_SUPERUSER_PASSWORD", "Admin.2025")
+        password = os.getenv("DJANGO_SUPERUSER_PASSWORD", "Revisao@2025")
 
         if not User.objects.filter(username=username).exists():
             User.objects.create_superuser(username=username, email=email, password=password)

--- a/revisao_segura/wsgi.py
+++ b/revisao_segura/wsgi.py
@@ -10,13 +10,8 @@ django.setup()
 # Rodar migrações automaticamente no início do deploy
 call_command("migrate")
 
-application = get_wsgi_application()
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'revisao_segura.settings')
-django.setup()
-
-call_command('migrate')
-print("Migrações aplicadas com sucesso!")
+# Garantir que o superusuário padrão exista
+call_command("create_superuser")
 
 application = get_wsgi_application()
 


### PR DESCRIPTION
## Summary
- update management command to create `Revisao2025` admin by default
- call `create_superuser` during WSGI startup so admin is recreated if missing

## Testing
- `python -m py_compile app/management/commands/create_superuser.py revisao_segura/wsgi.py`

------
https://chatgpt.com/codex/tasks/task_e_6855f7681410832a92c23c7099fe6376